### PR TITLE
Accommodate non-FHS build environments

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 
@@ -41,7 +41,7 @@ tar --numeric-owner --preserve-permissions --same-owner --acls --selinux --xattr
 systemctl --root=$mnt disable tpm-udev.path
 
 # Slice rootfs config out of fstab, since LABEL=cloudimg-rootfs doesn't exist in the container environment and systemd-remount-fs.service complains about not being able to find it
-chroot $mnt sed -i '/LABEL=cloudimg-rootfs/d' /etc/fstab
+chroot $mnt /usr/bin/sed -i '/LABEL=cloudimg-rootfs/d' /etc/fstab
 
 # Networking setup is expected to not actually cross a network boundary (i.e. only talk to the container host), so decrease the timeout because all operations here should be fast
 mkdir $mnt/etc/systemd/system/systemd-networkd-wait-online.service.d/


### PR DESCRIPTION
Resolves build failures on NixOS:

- `./build.sh: bad interpreter: /bin/bash: no such file or directory`
- `chroot: failed to run command ‘sed’: No such file or directory`

I also had to explicitly add `wget` to the environment since I don’t typically keep that around. Not sure how much detail you want to spend on documenting trivial dependencies though.