### PR TITLE
Avoid using APT to generate SSH host keys

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -53,14 +53,13 @@ EOF
 # Generate SSH keys on first boot
 cat > $mnt/etc/systemd/system/ssh-hostkey-generate.service <<EOF
 [Unit]
-Description=Properly configure OpenSSH keys on first container boot
+Description=Generate OpenSSH host keys before first use
 Before=ssh.service
 ConditionPathExists=!/etc/ssh/ssh_host_rsa_key
 
 [Service]
 Type=oneshot
-Environment=DEBIAN_FRONTEND=noninteractive
-ExecStart=apt-get install --reinstall -qq -y openssh-server
+ExecStart=ssh-keygen -A
 
 [Install]
 WantedBy=ssh.service


### PR DESCRIPTION
Techniques that leverage the `openssh-server` package’s `postinst` script risk two conflicts:

  - When `ssh.service` has been started by APT, attempting to trigger the `postinst` script by starting another instance of APT deadlocks.

  - When `ssh.service` has been started manually, the `postinst` run via `ssh-hostkey-generate.service` causes the proximal activation of `ssh.service` to be canceled, and e.g. Ansible tasks to fail.

To avoid these complications, invoke `ssh-keygen` directly. The `-A` option does exactly what we need:

> Generate host keys of all default key types (rsa, ecdsa, and ed25519) if they do not already exist.